### PR TITLE
Switch variable font origin

### DIFF
--- a/sources/Crispy.glyphs
+++ b/sources/Crispy.glyphs
@@ -30,7 +30,7 @@ value = 1;
 },
 {
 name = "Variable Font Origin";
-value = "8462F42F-4EB1-4423-BAD0-833446464E27";
+value = "1BCFA072-F94F-498F-956F-3AA5D600A933";
 }
 );
 date = "2018-06-13 01:37:59 +0000";
@@ -104,7 +104,7 @@ pos = -300;
 {
 }
 );
-name = "UltraCondensed Thin";
+name = "XTRA94-XOPQ2-YOPQ2";
 userData = {
 GSCornerRadius = 10;
 };

--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -16,36 +16,57 @@ fvarInstances:
       opsz: 48
       wdth: 100
       wght: 100
+      XTRA: 94
+      XOPQ: 2
+      YOPQ: 2
   - name: ExtraLight
     coordinates:
       opsz: 48
       wdth: 100
       wght: 200
+      XTRA: 94
+      XOPQ: 2
+      YOPQ: 2
   - name: Light
     coordinates:
       opsz: 48
       wdth: 100
       wght: 300
+      XTRA: 94
+      XOPQ: 2
+      YOPQ: 2
   - name: Regular
     coordinates:
       opsz: 48
       wdth: 100
       wght: 400
+      XTRA: 94
+      XOPQ: 2
+      YOPQ: 2
   - name: Medium
     coordinates:
       opsz: 48
       wdth: 100
       wght: 500
+      XTRA: 94
+      XOPQ: 2
+      YOPQ: 2
   - name: SemiBold
     coordinates:
       opsz: 48
       wdth: 100
       wght: 600
+      XTRA: 94
+      XOPQ: 2
+      YOPQ: 2
   - name: Bold
     coordinates:
       opsz: 48
       wdth: 100
       wght: 700
+      XTRA: 94
+      XOPQ: 2
+      YOPQ: 2
 
 stat:
   Crispy[SPAC,XOPQ,XTRA,YOPQ].ttf:


### PR DESCRIPTION
This PR switches the variable font origin to a thicker weight so it looks much better in font drop down menus. This is a halfway house fix for https://github.com/agyeiagyeiagyei/Crispy/issues/16.

<img width="400" height="221" alt="Screenshot 2026-02-13 at 13 45 39" src="https://github.com/user-attachments/assets/45e424b6-60d8-4318-b175-eb70cc12016f" />

