### PR TITLE
README: bump avar2-studio URL to v0.1.0.dev3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Crispy's avar2 mappings are authored with
 
 ```bash
 brew install fontc    # or: cargo install fontc
-pipx install https://github.com/agyeiagyeiagyei/avar2-studio/releases/latest/download/avar2_studio-0.1.0.dev1-py3-none-any.whl
+pipx install https://github.com/agyeiagyeiagyei/avar2-studio/releases/latest/download/avar2_studio-0.1.0.dev3-py3-none-any.whl
 avar2-studio sources/Crispy.glyphs
 ```
 


### PR DESCRIPTION
avar2-studio v0.1.0.dev1 and dev2 shipped without the `avar2_studio.build` module (a `.gitignore` pattern was excluding it). v0.1.0.dev3 is the first release that actually works end-to-end against this repo. Bump the install URL so following Crispy's README at this point lands on a working release.