### PR TITLE
README: bump avar2-studio URL to v0.1.0.dev5

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Crispy's avar2 mappings are authored with
 [avar2-studio](https://github.com/agyeiagyeiagyei/avar2-studio):
 
 ```bash
-brew install fontc    # or: cargo install fontc
-pipx install https://github.com/agyeiagyeiagyei/avar2-studio/releases/latest/download/avar2_studio-0.1.0.dev3-py3-none-any.whl
+pipx install https://github.com/agyeiagyeiagyei/avar2-studio/releases/latest/download/avar2_studio-0.1.0.dev5-py3-none-any.whl
 avar2-studio sources/Crispy.glyphs
 ```
 


### PR DESCRIPTION
Three releases of fixes since dev3 — see the avar2-studio commit log. dev5 is the first where the avar2 build path completes end-to-end on a freshly-installed wheel. Drops the `brew install fontc` line too since fontc now ships via its PyPI package.