### PR TITLE
Bump avar2-studio install URL to v0.1.0.dev6

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Crispy's avar2 mappings are authored with
 [avar2-studio](https://github.com/agyeiagyeiagyei/avar2-studio):
 
 ```bash
-pipx install https://github.com/agyeiagyeiagyei/avar2-studio/releases/latest/download/avar2_studio-0.1.0.dev5-py3-none-any.whl
+pipx install https://github.com/agyeiagyeiagyei/avar2-studio/releases/latest/download/avar2_studio-0.1.0.dev6-py3-none-any.whl
 avar2-studio sources/Crispy.glyphs
 ```
 


### PR DESCRIPTION
## Summary
- Points the README install URL at the newly-published avar2-studio v0.1.0.dev6 wheel.
- v0.1.0.dev6 adds .designspace support and a two-tier instance model on the avar2-studio side. Crispy's .glyphs flow is unchanged.

## Test plan
- [ ] Open the README in GitHub's renderer and confirm the install URL is correct